### PR TITLE
Fix perl warning

### DIFF
--- a/abi-dumper.pl
+++ b/abi-dumper.pl
@@ -3197,7 +3197,7 @@ sub formatName($$)
     
     if(defined $LambdaSupport)
     { # struct {lambda()}
-        $N=~s/(\w){/$1 {/g;
+        $N=~s/(\w)\{/$1 \{/g;
     }
     
     return ($Cache{"formatName"}{$_[1]}{$_[0]} = $N);


### PR DESCRIPTION
- Unescaped left brace in regex is deprecated here (and will be fatal in
  Perl 5.30), passed through in regex; marked by <-- HERE in m/(\w){ <--
  HERE / at /usr/bin/abi-dumper line 3200.