### PR TITLE
drop <built-in> header when we dump symbols

### DIFF
--- a/abi-dumper.pl
+++ b/abi-dumper.pl
@@ -4340,6 +4340,10 @@ sub setSource(@)
         if(not $Name) {
             $Name = $InfoName;
         }
+
+        if(index($Name, "<built-in>")!=-1) {
+            return;
+        }
         
         if($Name=~/\.($HEADER_EXT)\Z/i
         or index($Name, ".")==-1)
@@ -4358,7 +4362,7 @@ sub setSource(@)
                 }
             }
         }
-        elsif(index($Name, "<built-in>")==-1)
+        else
         { # source
             if(not defined $Target or $Target eq "Source")
             {


### PR DESCRIPTION
hello! We use abi-dumper on opencloudos 23 recently, and when I deal with the output of abi-dumper I found the "built-in" in header files is useless(it is not a specified header). So I think it may be dropped when we dump symbols.