### PR TITLE
Allow the user to set the ctags binary

### DIFF
--- a/abi-dumper.pl
+++ b/abi-dumper.pl
@@ -60,6 +60,11 @@ my $EU_READELF = "eu-readelf";
 my $EU_READELF_L = $LOCALE." ".$EU_READELF;
 my $OBJDUMP = "objdump";
 my $CTAGS = "ctags";
+
+if ( $ENV{"CTAGS"} eq "") {
+    my $CTAGS = $ENV{"CATGS"); 
+}
+
 my $EXUBERANT_CTAGS = 0;
 my $GPP = "g++";
 

--- a/abi-dumper.pl
+++ b/abi-dumper.pl
@@ -60,11 +60,7 @@ my $EU_READELF = "eu-readelf";
 my $EU_READELF_L = $LOCALE." ".$EU_READELF;
 my $OBJDUMP = "objdump";
 my $CTAGS = "ctags";
-
-if ( $ENV{"CTAGS"} eq "") {
-    my $CTAGS = $ENV{"CATGS"); 
-}
-
+my $CTAGS = $ENV{"CTAGS"} ? $ENV{"CTAGS"} : "ctags";
 my $EXUBERANT_CTAGS = 0;
 my $GPP = "g++";
 


### PR DESCRIPTION
In some distros (e.g OpenSUSE) universal ctags is installed as universal-ctags. This change allows the user to set the binary of ctags to anything using the $CTAGS env variable.